### PR TITLE
Fix missing logger attribute in bot initialization

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -15350,6 +15350,9 @@ class EnhancedTradingBot:
     def __init__(self):
         print("🚀 [Bot Init] Starting EnhancedTradingBot initialization...")
         
+        # Initialize logger first
+        self.logger = BOT_LOGGERS['BotAnalysis']
+        
         # Core trading attributes
         print("🔧 [Bot Init] Setting up core trading attributes...")
         self.active_symbols = set(SYMBOLS)  # Initialize with all symbols from SYMBOLS list


### PR DESCRIPTION
Initialize `self.logger` in `EnhancedTradingBot.__init__` to resolve an `AttributeError` when accessing the logger before it was defined.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5643459-68b0-4d70-9ab4-db57343bd7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5643459-68b0-4d70-9ab4-db57343bd7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

