### PR TITLE
Remove trading economics wait config

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -1897,7 +1897,7 @@ GOOGLE_AI_API_KEY = "AIzaSyBCexoODvgrN2QRG8_iKv3p5VTJ5jaJ_B0"
 TRADING_ECONOMICS_API_KEY = "a284ad0cdba547c:p5oyv77j6kovqhv"  
 TRADING_ECONOMICS_LAST_CALL = 0  # Track last API call time for rate limiting
 TRADING_ECONOMICS_CACHE = {}  # Cache for API responses
-TRADING_ECONOMICS_RATE_LIMIT = 60  # Minimum seconds between API calls
+TRADING_ECONOMICS_RATE_LIMIT = 0  # No wait between API calls
 
 # Risk Management Configuration
 RISK_MANAGEMENT = {


### PR DESCRIPTION
Remove the 1-minute wait configuration for Trading Economics API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-e34db804-1ad3-475a-b6b0-6d01d44dec7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e34db804-1ad3-475a-b6b0-6d01d44dec7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

